### PR TITLE
Tile Flip and Line Limit

### DIFF
--- a/src/gpu/oam-draw-helper.ts
+++ b/src/gpu/oam-draw-helper.ts
@@ -1,0 +1,46 @@
+import { ObjectAttributeMemoryRegister } from "@/memory/shared-memory-registers/lcd-display-registers/object-attribute-memory-registers";
+import { EnhancedImageData } from "@/helpers/enhanced-image-data";
+
+class OamDrawHelper {
+  oamRegister: ObjectAttributeMemoryRegister | null = null;
+  private characterDataStart = 0x8000;
+  private spriteOffset = {
+    x: -8,
+    y: -16,
+  }
+
+
+  // private reset() {
+  //   this.tileByteStart = 0;
+  //   this.pixelHeight = 8;
+  //   this.isFlippedX = false;
+  //   this.isFlippedY = false;
+  // }
+
+  forRegister(oamRegister: ObjectAttributeMemoryRegister) {
+    this.oamRegister = oamRegister;
+    return this;
+  }
+
+  drawTileLine(enhancedImageData: EnhancedImageData, lineY: number) {
+
+  }
+
+  // tileStartingAt(byteIndex: number) {
+  //   this.reset();
+  //
+  //   this.tileByteStart = byteIndex;
+  //   return this;
+  // }
+  //
+  // height(pixelHeight: 8 | 16) {
+  //   this.pixelHeight = pixelHeight;
+  //   return this;
+  // }
+  //
+  // flipped(isFlippedX: boolean, isFlippedY: boolean) {
+  //   this.isFlippedX = isFlippedX;
+  //   this.isFlippedY = isFlippedY;
+  //   return this;
+  // }
+}

--- a/src/helpers/gpu-debug-helpers.ts
+++ b/src/helpers/gpu-debug-helpers.ts
@@ -17,7 +17,7 @@ const colors = [
 const CharacterDataStart = 0x8000;
 const CharacterDataEnd = 0x97ff;
 
-const oamImageDate = new EnhancedImageData(320, 320);
+let oamImageDate = new EnhancedImageData(320, 320);
 
 export function backgroundTilesToImageData(): ImageData {
   let backgroundTileMap: Uint8Array | Int8Array;
@@ -78,7 +78,7 @@ function drawTileAt(imageData: EnhancedImageData, x: number, y: number, charData
   }
 }
 
-function drawSpriteTileAt(imageData: EnhancedImageData, x: number, y: number, charData: Uint8Array, tileStart: number, palette: number[]) {
+export function drawSpriteTileAt(imageData: EnhancedImageData, x: number, y: number, charData: Uint8Array, tileStart: number, palette: number[]) {
   let imageDataX = x;
   let imageDataY = y;
 
@@ -131,6 +131,28 @@ export function drawOam(): ImageData {
 
   return oamImageDate;
 }
+
+export function drawOamToBackground(): ImageData {
+  const bytesPerLine = 2;
+  const linesPerTile = 8; // TODO: Update to account for 16px high tiles, which are not yet implemented
+  const bytesPerTile = bytesPerLine * linesPerTile;
+  const characterDataStart = 0x8000;
+  oamImageDate = new EnhancedImageData(320, 320);
+
+
+  objectAttributeMemoryRegisters.forEach(oamRegister => {
+    const { characterCode, paletteNumber } = oamRegister;
+    const tileCharBytePosition = characterCode * bytesPerTile;
+    const currentTileBytePosition = characterDataStart + tileCharBytePosition;
+
+    const palette = objectPaletteRegisters[paletteNumber].palette;
+
+    drawSpriteTileAt(oamImageDate, oamRegister.xPosition - 8, oamRegister.yPosition - 16, memory.memoryBytes, currentTileBytePosition, palette);
+  });
+
+  return oamImageDate;
+}
+
 
 export function characterImageData(): ImageData {
   const characterData = memory.memoryBytes.subarray(CharacterDataStart, CharacterDataEnd);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 import { cartridge } from "@/cartridge/cartridge";
-import { backgroundTilesToImageData, characterImageData, drawOam } from "@/helpers/gpu-debug-helpers";
+import {
+  backgroundTilesToImageData,
+  characterImageData,
+  drawOam,
+  drawOamToBackground
+} from "@/helpers/gpu-debug-helpers";
 import { Gameboy } from "@/gameboy";
 import { GameboyButton } from "@/input/gameboy-button.enum";
 import { memory } from "@/memory/memory";
@@ -117,12 +122,14 @@ async function onFileChange(event: Event) {
       // vramContext.drawImage( vramCanvas, 0, 0, 8*vramCanvas.width, 8*vramCanvas.height );
 
       backgroundContext.imageSmoothingEnabled = false;
+      // backgroundContext.clearRect(0, 0, 600, 600);
+
       backgroundContext.putImageData(backgroundTilesToImageData(), 0, 0);
-      backgroundContext.drawImage( backgroundCanvas, 0, 0, 2*backgroundCanvas.width, 2*backgroundCanvas.height );
+
 
       oamContext.imageSmoothingEnabled = false;
+      oamContext.clearRect(0, 0, 512, 512);
       oamContext.putImageData(drawOam(), 0, 0);
-      scaledDrawContext.clearRect(0, 0, 640, 576);
       oamContext.drawImage(oamCanvas, 0, 0, 8*oamCanvas.width, 8*oamCanvas.height );
     });
 


### PR DESCRIPTION
* Support flipping tiles horizontally and vertically
* limit sprites to 10 per line per gameboy spec.

TODO: Cleanup drawing code, possibly moving into helper class