### PR TITLE
Fix bad cycle time calcs, fixes #49

### DIFF
--- a/emulator/src/cpu/operations/create-jump-operations.ts
+++ b/emulator/src/cpu/operations/create-jump-operations.ts
@@ -117,7 +117,7 @@ export function createJumpOperations(this: CPU) {
       }
     },
     byteDefinition: 0b00_100_000,
-    cycleTime: !registers.F.isResultZero ? 12 : 8,
+    get cycleTime() { return !registers.F.isResultZero ? 12 : 8 },
     byteLength: 2,
     execute() {
       if (!registers.F.isResultZero) {
@@ -140,7 +140,7 @@ export function createJumpOperations(this: CPU) {
       }
     },
     byteDefinition: 0b00_101_000,
-    cycleTime: registers.F.isResultZero ? 12 : 8,
+    get cycleTime() { return registers.F.isResultZero ? 12 : 8 },
     byteLength: 2,
     execute() {
       if (registers.F.isResultZero) {
@@ -163,7 +163,7 @@ export function createJumpOperations(this: CPU) {
       }
     },
     byteDefinition: 0b00_110_000,
-    cycleTime: !registers.F.isCarry ? 12 : 8,
+    get cycleTime() { return !registers.F.isCarry ? 12 : 8 },
     byteLength: 2,
     execute() {
       if (!registers.F.isCarry) {
@@ -186,7 +186,7 @@ export function createJumpOperations(this: CPU) {
       }
     },
     byteDefinition: 0b00_111_000,
-    cycleTime: registers.F.isCarry ? 12 : 8,
+    get cycleTime() { return registers.F.isCarry ? 12 : 8 },
     byteLength: 2,
     execute() {
       if (registers.F.isCarry) {

--- a/emulator/src/gpu/gpu.ts
+++ b/emulator/src/gpu/gpu.ts
@@ -122,12 +122,6 @@ export class GPU {
     }
   }
 
-  // The gpu logic now passes the acid test, however it achieves background/window vs sprite priority
-  // by returning all pixel values per line out of drawBackgroundLine and drawWindowLine and sending them into
-  // drawSpriteLine. While this does work, it feels a bit clunky. A possible better solution is to update
-  // drawSpriteLine to go per pixel from left to right and draw out the intersecting sprites. While this is initially
-  // less performant than currently just drawing only the sprites that intersect the y line, it would allow all
-  // three methods to use generator functions to return each pixel. Might be worth the tradeoff overall.
   drawScanline() {
     if (!lcdControlRegister.isLCDControllerOperating) {
       return;


### PR DESCRIPTION
Remove comment from gpu class, as I tried this approach and the performance was worse and the code was harder to read. Instead made some small tweaks to my current approach to improve performance.